### PR TITLE
Fix slippage compenstation

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -136,7 +136,7 @@ function Timer:is_active()
 	return self.active == true
 end
 
-function Timer:expire()
+function Timer:expire(elapsed)
 	self.fn(self.elapsed)
 	if self.elapsed and self.elapsed > 0.0 then
 		-- we could set it here to 0.0, but it's nice

--- a/init.lua
+++ b/init.lua
@@ -136,13 +136,13 @@ function Timer:is_active()
 	return self.active == true
 end
 
-function Timer:expire(elapsed)
+function Timer:expire()
 	self.fn(self.elapsed)
 	if self.elapsed and self.elapsed > 0.0 then
 		-- we could set it here to 0.0, but it's nice
 		-- to account for the slippage and be a little
 		-- bit more accurate
-		self.elapsed = 0.0 + (self.interval - self.elapsed)
+		self.elapsed = self.elapsed - self.interval
 	end
 	if not self.repeats then
 		self:stop()

--- a/timerdemo/init.lua
+++ b/timerdemo/init.lua
@@ -11,11 +11,11 @@ assert(s)
 
 -- our timer functions
 local mytimerfunc1 = function(elapsed)
-	print("fn1: ", elapsed)
+	print("fn1: ", minetest.get_us_time(), elapsed)
 end
 
 local mytimerfunc2 = function(elapsed)
-	print("fn2: ", elapsed)
+	print("fn2: ", minetest.get_us_time(), elapsed)
 end
 
 -- our timers

--- a/timerdemo/init.lua
+++ b/timerdemo/init.lua
@@ -35,7 +35,7 @@ local t2 = Timer(mytimerfunc2, {
 
 -- t3, does not repeat, anonymous function, not persistent.
 local t3 = Timer(function(elapsed)
-		print("fn3: ", elapsed)
+		print("fn3: ", minetest.get_us_time(), elapsed)
 	end
 	, {
 	interval = 5.3,


### PR DESCRIPTION
Current calculation sets `elapsed` to a negative value, thus making delay greater than `interval` while it should be less (by `fn` execution time approximately).